### PR TITLE
Add job execution condition

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -53,6 +53,7 @@ jobs:
     secrets: inherit
 
   sync-version:
+    if: ${{ needs.check-version.outputs.TAG_DIFF_LIST_JSON_LEN != '0' }}
     needs:
       - check-version
     uses: vdaas/vald-client-ci/.github/workflows/_sync-version.yaml@main


### PR DESCRIPTION
Add a condition for job since the error occurs when there is no version difference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the synchronization process by ensuring it only runs when there are version changes detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->