### PR TITLE
Add logic to set latest release label

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,16 +33,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check if tag is a LATEST.
+        id: check_latest
+        run: |
+          TAG=$(echo "$GITHUB_REF" | sed -e 's:^refs/tags/::')  # e.g) v1.7.6
+          LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1) # e.g) v1.7.6
+
+          if [ "${TAG}" = "${LATEST_TAG}" ]; then
+            echo "IS_LATEST_RELEASE=true" | tee -a $GITHUB_OUTPUT↴
+          else
+            echo "IS_LATEST_RELEASE=false" | tee -a $GITHUB_OUTPUT↴
+          fi
       - name: Create release
-        id: create_release
-        uses: actions/create-release@v1.0.0
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          name: Release ${{ github.ref }}
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
+          make_latest: ${{ steps.check_latest.outputs.IS_LATEST_RELEASE }}
 
   publish-pypl:
     if: ${{ startsWith( github.ref, 'refs/tags/') && inputs.client_type == 'python'}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,11 +71,11 @@ jobs:
       - name: Prepare for publish
         run: |
           make ci/package/prepare
-      # - name: Publish
-      #   uses: pypa/gh-action-pypi-publish@master
-      #   with:
-      #     user: ${{ secrets.PIP_USERNAME }}
-      #     password: ${{ secrets.PIP_TOKEN }}
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: ${{ secrets.PIP_USERNAME }}
+          password: ${{ secrets.PIP_TOKEN }}
 
   publish-npm:
     if: ${{ startsWith( github.ref, 'refs/tags/') && inputs.client_type == 'node'}}
@@ -90,11 +90,11 @@ jobs:
       - name: Prepare for publish
         run: |
           make ci/package/prepare
-      # - name: Publish
-      #   run: |
-      #     make ci/package/publish
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - name: Publish
+        run: |
+          make ci/package/publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
   publish-maven:
     if: ${{ startsWith( github.ref, 'refs/tags/') && inputs.client_type == 'java'}}
@@ -112,9 +112,9 @@ jobs:
       - name: Prepare for publish
         run: |
           make ci/package/prepare
-      # - name: Publish
-      #   run: |
-      #     make ci/package/publish
+      - name: Publish
+        run: |
+          make ci/package/publish
 
   publish-clojars:
     if: ${{ startsWith( github.ref, 'refs/tags/') && inputs.client_type == 'clj'}}
@@ -126,9 +126,9 @@ jobs:
       - name: Prepare for publish
         run: |
           make ci/package/prepare
-      # - name: Publish
-      #   run: |
-      #     make ci/package/publish
-      #   env:
-      #     CLOJARS_USER: ${{ secrets.CLOJARS_USER }}
-      #     CLOJARS_PASS: ${{ secrets.CLOJARS_PASS }}
+      - name: Publish
+        run: |
+          make ci/package/publish
+        env:
+          CLOJARS_USER: ${{ secrets.CLOJARS_USER }}
+          CLOJARS_PASS: ${{ secrets.CLOJARS_PASS }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,12 +46,13 @@ jobs:
           else
             echo "IS_LATEST_RELEASE=false" | tee -a $GITHUB_OUTPUT
           fi
+          echo "TAG=${TAG}" | tee -a $GITHUB_OUTPUT
       - name: Create release
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: Release ${{ github.ref }}
+          name: Release ${{ steps.check_latest.outputs.TAG }}
           tag_name: ${{ github.ref }}
           draft: false
           prerelease: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,9 +42,9 @@ jobs:
           LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1) # e.g) v1.7.6
 
           if [ "${TAG}" = "${LATEST_TAG}" ]; then
-            echo "IS_LATEST_RELEASE=true" | tee -a $GITHUB_OUTPUT↴
+            echo "IS_LATEST_RELEASE=true" | tee -a $GITHUB_OUTPUT
           else
-            echo "IS_LATEST_RELEASE=false" | tee -a $GITHUB_OUTPUT↴
+            echo "IS_LATEST_RELEASE=false" | tee -a $GITHUB_OUTPUT
           fi
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,11 +70,11 @@ jobs:
       - name: Prepare for publish
         run: |
           make ci/package/prepare
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: ${{ secrets.PIP_USERNAME }}
-          password: ${{ secrets.PIP_TOKEN }}
+      # - name: Publish
+      #   uses: pypa/gh-action-pypi-publish@master
+      #   with:
+      #     user: ${{ secrets.PIP_USERNAME }}
+      #     password: ${{ secrets.PIP_TOKEN }}
 
   publish-npm:
     if: ${{ startsWith( github.ref, 'refs/tags/') && inputs.client_type == 'node'}}
@@ -89,11 +89,11 @@ jobs:
       - name: Prepare for publish
         run: |
           make ci/package/prepare
-      - name: Publish
-        run: |
-          make ci/package/publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      # - name: Publish
+      #   run: |
+      #     make ci/package/publish
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
   publish-maven:
     if: ${{ startsWith( github.ref, 'refs/tags/') && inputs.client_type == 'java'}}
@@ -111,9 +111,9 @@ jobs:
       - name: Prepare for publish
         run: |
           make ci/package/prepare
-      - name: Publish
-        run: |
-          make ci/package/publish
+      # - name: Publish
+      #   run: |
+      #     make ci/package/publish
 
   publish-clojars:
     if: ${{ startsWith( github.ref, 'refs/tags/') && inputs.client_type == 'clj'}}
@@ -125,9 +125,9 @@ jobs:
       - name: Prepare for publish
         run: |
           make ci/package/prepare
-      - name: Publish
-        run: |
-          make ci/package/publish
-        env:
-          CLOJARS_USER: ${{ secrets.CLOJARS_USER }}
-          CLOJARS_PASS: ${{ secrets.CLOJARS_PASS }}
+      # - name: Publish
+      #   run: |
+      #     make ci/package/publish
+      #   env:
+      #     CLOJARS_USER: ${{ secrets.CLOJARS_USER }}
+      #     CLOJARS_PASS: ${{ secrets.CLOJARS_PASS }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,11 +41,7 @@ jobs:
           TAG=$(echo "$GITHUB_REF" | sed -e 's:^refs/tags/::')  # e.g) v1.7.6
           LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1) # e.g) v1.7.6
 
-          if [ "${TAG}" = "${LATEST_TAG}" ]; then
-            echo "IS_LATEST_RELEASE=true" | tee -a $GITHUB_OUTPUT
-          else
-            echo "IS_LATEST_RELEASE=false" | tee -a $GITHUB_OUTPUT
-          fi
+          echo "IS_LATEST_RELEASE=$([ "${TAG}" = "${LATEST_TAG}" ] && echo true || echo false)" | tee -a $GITHUB_OUTPUT
           echo "TAG=${TAG}" | tee -a $GITHUB_OUTPUT
       - name: Create release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
If the [create-release](https://github.com/actions/create-release) action is used, the most recent release is treated as the LATEST release. Also, since it is a read-only project, we need to use other external actions.

In this PR, I added logic to determine whether to set the LATEST tag or not, and changed it to use [other](https://github.com/softprops/action-gh-release) actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Updated GitHub Actions workflow for creating releases to improve automation and reliability.
  - Refactored the release workflow to enhance efficiency and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->