### PR TITLE
[Bugfix]: Ignore vald-client-ci and vald repo in actions update command

### DIFF
--- a/.github/actions/setup-language/action.yaml
+++ b/.github/actions/setup-language/action.yaml
@@ -31,13 +31,13 @@ runs:
       uses: vdaas/vald/.github/actions/setup-go@main
     - name: Setup Node environment
       if: ${{ inputs.client_type == 'node' }}
-      uses: vdaas/vald-client-ci/.github/actions/setup-node@v4
+      uses: vdaas/vald-client-ci/.github/actions/setup-node@main
     - name: Setup Python environment
       if: ${{ inputs.client_type == 'python' }}
-      uses: vdaas/vald-client-ci/.github/actions/setup-python@v5
+      uses: vdaas/vald-client-ci/.github/actions/setup-python@main
     - name: Setup Java environment
       if: ${{ inputs.client_type == 'java' }}
-      uses: vdaas/vald-client-ci/.github/actions/setup-java@v4
+      uses: vdaas/vald-client-ci/.github/actions/setup-java@main
     - name: Setup Clojure environment
       if: ${{ inputs.client_type == 'clj' }}
       uses: vdaas/vald-client-ci/.github/actions/setup-clj@main

--- a/Makefile.d/function.mk
+++ b/Makefile.d/function.mk
@@ -19,13 +19,13 @@ define update-github-actions
 				fi; \
 				if [ "$$ACTION_NAME" = "cirrus-actions/rebase" ]; then \
 					VERSION_PREFIX=$$VERSION; \
-					find $(ROOTDIR)/.github -type f -exec sed -i -e "/vdaas\/vald-client-ci\|vdaas\/vald\//! s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \
+					find $(ROOTDIR)/.github -type f -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \
 				elif echo $$VERSION | grep -qE '^[0-9]'; then \
 					VERSION_PREFIX=`echo $$VERSION | cut -c 1`; \
-					find $(ROOTDIR)/.github -type f -exec sed -i -e "/vdaas\/vald-client-ci\|vdaas\/vald\//! s%$$ACTION_NAME@.*%$$ACTION_NAME@v$$VERSION_PREFIX%g" {} +; \
+					find $(ROOTDIR)/.github -type f -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@v$$VERSION_PREFIX%g" {} +; \
 				else \
 					VERSION_PREFIX=$$VERSION; \
-					find $(ROOTDIR)/.github -type f -exec sed -i -e "/vdaas\/vald-client-ci\|vdaas\/vald\//! s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \
+					find $(ROOTDIR)/.github -type f -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \
 				fi; \
 			else \
 				echo "No action version file found for $$ACTION_NAME version file $$FILE_NAME" >&2; \

--- a/Makefile.d/function.mk
+++ b/Makefile.d/function.mk
@@ -19,13 +19,13 @@ define update-github-actions
 				fi; \
 				if [ "$$ACTION_NAME" = "cirrus-actions/rebase" ]; then \
 					VERSION_PREFIX=$$VERSION; \
-					find $(ROOTDIR)/.github -type f -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \
+					find $(ROOTDIR)/.github -type f -exec sed -i -e "/vdaas\/vald-client-ci\|vdaas\/vald\//! s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \
 				elif echo $$VERSION | grep -qE '^[0-9]'; then \
 					VERSION_PREFIX=`echo $$VERSION | cut -c 1`; \
-					find $(ROOTDIR)/.github -type f -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@v$$VERSION_PREFIX%g" {} +; \
+					find $(ROOTDIR)/.github -type f -exec sed -i -e "/vdaas\/vald-client-ci\|vdaas\/vald\//! s%$$ACTION_NAME@.*%$$ACTION_NAME@v$$VERSION_PREFIX%g" {} +; \
 				else \
 					VERSION_PREFIX=$$VERSION; \
-					find $(ROOTDIR)/.github -type f -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \
+					find $(ROOTDIR)/.github -type f -exec sed -i -e "/vdaas\/vald-client-ci\|vdaas\/vald\//! s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \
 				fi; \
 			else \
 				echo "No action version file found for $$ACTION_NAME version file $$FILE_NAME" >&2; \

--- a/Makefile.d/function.mk
+++ b/Makefile.d/function.mk
@@ -1,3 +1,8 @@
+
+# NOTE:
+# The version of the local action inside the setup-language action also changes, so it is excluded from the `find` command.
+# As this is a special case, it was discussed to exclude it from the `find` command without using `sed` command to deal with it.
+
 define update-github-actions
 	@set -e; for ACTION_NAME in $1; do \
 		if [ -n "$$ACTION_NAME" ] && [ "$$ACTION_NAME" != "security-and-quality" ]; then \
@@ -22,7 +27,7 @@ define update-github-actions
 					find $(ROOTDIR)/.github -type f -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \
 				elif echo $$VERSION | grep -qE '^[0-9]'; then \
 					VERSION_PREFIX=`echo $$VERSION | cut -c 1`; \
-					find $(ROOTDIR)/.github -type f -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@v$$VERSION_PREFIX%g" {} +; \
+					find $(ROOTDIR)/.github -type f -not -path "$(ROOTDIR)/.github/actions/setup-language/*" -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@v$$VERSION_PREFIX%g" {} +; \
 				else \
 					VERSION_PREFIX=$$VERSION; \
 					find $(ROOTDIR)/.github -type f -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \


### PR DESCRIPTION
An error occurred on each client side because the tags in the local action had been rewritten.

## NOTE
The following is the CI error.

https://github.com/vdaas/vald-client-java/actions/runs/9079385414/job/24980205233?pr=264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Updated GitHub Actions setup for Node, Python, and Java to use the latest main versions.
  - Improved Makefile to exclude specific patterns during search and replace operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->