### PR TITLE
Fix job execution condition for auto-merge

### DIFF
--- a/.github/workflows/_pr-auto-merge.yaml
+++ b/.github/workflows/_pr-auto-merge.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || ( github.event.pull_request.user.login == 'vdaas-ci' && startsWith(github.event.pull_request.title, 'Bump') ) }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || ( github.event.pull_request.user.login == 'vdaas-ci' && startsWith(github.event.pull_request.title, 'Bump') ) || startsWith(github.event.pull_request.title, '[Snyk]') }}
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies


### PR DESCRIPTION
The job execution condition has been fixed so that automatic merging is possible even if the following case.

https://github.com/vdaas/vald-client-clj/pull/109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub workflow to include conditional checks for pull request titles starting with '[Snyk]' for auto-merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->