### PR TITLE
Add workflow to backport dependency update PR to release branch

### DIFF
--- a/.github/workflows/_backport-deps.yaml
+++ b/.github/workflows/_backport-deps.yaml
@@ -1,0 +1,98 @@
+#
+# Copyright (C) 2019-2024 vdaas.org vald team <vald@vdaas.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: "Run backport deps update PR"
+on:
+  workflow_call:
+    secrets:
+      CI_TOKEN:
+        required: true
+      GPG_PRIVATE_KEY:
+        required: true
+
+env:
+  DEPS_UPDATE_PR_TITLE_REGEX: "^(chore\\(deps\\): bump|\\[Snyk\\])"
+  BACKPORT_BRANCH_NAME_PREFIX: "backport"
+  FETCHED_GITHUB_INFO_PATH: github_info.json
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.CI_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
+      - name: Set Git config
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+      - name: Fetch all branches
+        run: |
+          git fetch --all
+      - name: Get PR info
+        id: get_pr
+        run: |
+          gh pr list --limit 10 --json number,title,body,labels,headRefName,headRefOid,mergeCommit --state merged |
+            jq --arg oid "${GITHUB_SHA}" '.[] | select(.mergeCommit.oid == $oid)' > ${FETCHED_GITHUB_INFO_PATH}
+          cat ${FETCHED_GITHUB_INFO_PATH}
+
+          PR_NUM=$(cat ${FETCHED_GITHUB_INFO_PATH} | jq -r --arg REGEX "${DEPS_UPDATE_PR_TITLE_REGEX}" 'select(.title | test($REGEX)) | .number')
+          echo "PR_NUM=${PR_NUM}" | tee -a $GITHUB_OUTPUT
+          echo "${GITHUB_SHA}"
+      - name: Get all release branches
+        id: get_branch
+        run: |
+          RELEASE_BRANCHES=$(git branch -r | tr -d ' ' | grep '^origin/release/v[0-9]\+\.[0-9]\+' | sed 's/origin\///g' | tr '\n' ' ' | sed 's/ $//')
+          if [ -z "${RELEASE_BRANCHES}" ]; then
+            echo "There are no release branches."
+          fi
+          echo "RELEASE_BRANCHES=${RELEASE_BRANCHES}" | tee -a $GITHUB_OUTPUT
+      - name: Create PR
+        if: ${{ steps.get_branch.outputs.RELEASE_BRANCHES != '' && steps.get_pr.outputs.PR_NUM != '' }}
+        env:
+          RELEASE_BRANCHES: ${{ steps.get_branch.outputs.RELEASE_BRANCHES }}
+        run: |
+          PR_TITLE=`cat $FETCHED_GITHUB_INFO_PATH | jq -r ".title"`
+          PR_BODY=`cat $FETCHED_GITHUB_INFO_PATH | jq -r ".body"`
+          PR_NUM=`cat $FETCHED_GITHUB_INFO_PATH | jq -r ".number"`
+          PR_BRANCH_NAME=`cat $FETCHED_GITHUB_INFO_PATH | jq -r ".headRefName"`
+
+          echo "${PR_NUM} ${PR_TITLE}: ${PR_BODY}"
+
+          for BRANCH_NAME in ${RELEASE_BRANCHES}; do
+              BACKPORT_BRANCH_NAME="${BACKPORT_BRANCH_NAME_PREFIX}/${BRANCH_NAME}/${PR_BRANCH_NAME}"   # e.g) backport/release/vx.x/{current branch name}
+
+              echo "BRANCH_NAME=${BRANCH_NAME}"
+              echo "BACKPORT_BRANCH_NAME=${BACKPORT_BRANCH_NAME}"
+              echo "SHA=${GITHUB_SHA}"
+
+              git checkout ${BRANCH_NAME}
+              git checkout -b ${BACKPORT_BRANCH_NAME}
+
+              # Force cherry-pick. The conflicts will be modified within the backport PR.
+              git cherry-pick ${GITHUB_SHA} || (git add -A && git cherry-pick --continue --no-edit)
+              git push origin ${BACKPORT_BRANCH_NAME}
+
+              gh pr create --base ${BRANCH_NAME} \
+                           --title "Backport PR #${PR_NUM} to ${BRANCH_NAME} for ${PR_TITLE}" \
+                           --body "${PR_BODY}"
+          done

--- a/.github/workflows/_backport-deps.yaml
+++ b/.github/workflows/_backport-deps.yaml
@@ -25,6 +25,7 @@ on:
 env:
   DEPS_UPDATE_PR_TITLE_REGEX: "^(chore\\(deps\\): bump|\\[Snyk\\])"
   BACKPORT_BRANCH_NAME_PREFIX: "backport"
+  BACKPORT_PR_TITLE_PREFIX: "chore(deps): bump"
   FETCHED_GITHUB_INFO_PATH: github_info.json
 
 jobs:
@@ -93,6 +94,6 @@ jobs:
               git push origin ${BACKPORT_BRANCH_NAME}
 
               gh pr create --base ${BRANCH_NAME} \
-                           --title "Backport PR #${PR_NUM} to ${BRANCH_NAME} for ${PR_TITLE}" \
+                           --title "${BACKPORT_PR_TITLE_PREFIX} backport PR #${PR_NUM} to ${BRANCH_NAME} for ${PR_TITLE}" \
                            --body "${PR_BODY}"
           done

--- a/.github/workflows/_backport-deps.yaml
+++ b/.github/workflows/_backport-deps.yaml
@@ -21,13 +21,11 @@ on:
         required: true
       GPG_PRIVATE_KEY:
         required: true
-
 env:
   DEPS_UPDATE_PR_TITLE_REGEX: "^(chore\\(deps\\): bump|\\[Snyk\\])"
   BACKPORT_BRANCH_NAME_PREFIX: "backport"
   BACKPORT_PR_TITLE_PREFIX: "chore(deps): bump"
   FETCHED_GITHUB_INFO_PATH: github_info.json
-
 jobs:
   backport:
     runs-on: ubuntu-latest
@@ -62,7 +60,7 @@ jobs:
       - name: Get all release branches
         id: get_branch
         run: |
-          RELEASE_BRANCHES=$(git branch -r | tr -d ' ' | grep '^origin/release/v[0-9]\+\.[0-9]\+' | sed 's/origin\///g' | tr '\n' ' ' | sed 's/ $//')
+          RELEASE_BRANCHES=$(git branch -r | tr -d ' ' | grep '^origin/release/v[0-9]\+\.[0-9]\+$' | sed 's/origin\///g' | tr '\n' ' ' | sed 's/ $//')
           if [ -z "${RELEASE_BRANCHES}" ]; then
             echo "There are no release branches."
           fi

--- a/.github/workflows/_pr-auto-merge.yaml
+++ b/.github/workflows/_pr-auto-merge.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || ( github.event.pull_request.user.login == 'vdaas-ci' && startsWith(github.event.pull_request.title, 'Bump') ) || startsWith(github.event.pull_request.title, '[Snyk]') }}
+    if: "${{ github.event.pull_request.user.login == 'dependabot[bot]' || ( github.event.pull_request.user.login == 'vdaas-ci' && startsWith(github.event.pull_request.title, 'chore(deps): bump') ) || startsWith(github.event.pull_request.title, '[Snyk]') }}"
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/_update-deps.yaml
+++ b/.github/workflows/_update-deps.yaml
@@ -21,6 +21,10 @@ on:
         description: "Set config file path for dependabot CLI"
         type: string
         required: true
+      pr_branch_name:
+        description: "Set the branch name for PR creation"
+        type: string
+        required: true
     secrets:
       CI_USER:
         required: true
@@ -64,8 +68,10 @@ jobs:
           author: "${{ secrets.CI_USER }} <vald@vdaas.org>"
           token: ${{ secrets.CI_TOKEN }}
           committer: "${{ secrets.CI_USER }} <vald@vdaas.org>"
+          commit-message: "automated changes"
           signoff: true
           delete-branch: true
           base: main
+          branch: ${{ inputs.pr_branch_name }}
           title: "chore(deps): bump dependency updates"
           body: "Automated pull request to update dependencies."

--- a/.github/workflows/_update-deps.yaml
+++ b/.github/workflows/_update-deps.yaml
@@ -67,5 +67,5 @@ jobs:
           signoff: true
           delete-branch: true
           base: main
-          title: "Bump dependencies updates"
+          title: "chore(deps): bump dependency updates"
           body: "Automated pull request to update dependencies."

--- a/.github/workflows/update-actions.yaml
+++ b/.github/workflows/update-actions.yaml
@@ -46,5 +46,5 @@ jobs:
           signoff: true
           delete-branch: true
           base: main
-          title: "Update Actions dependency"
-          body: "Automated pull request to update Actions."
+          title: "chore(deps): bump GitHub Actions dependency updates"
+          body: "Automated pull request to update GitHub Actions dependencies."

--- a/.github/workflows/update-actions.yaml
+++ b/.github/workflows/update-actions.yaml
@@ -43,8 +43,10 @@ jobs:
           author: "${{ secrets.CI_USER }} <vald@vdaas.org>"
           token: ${{ secrets.CI_TOKEN }}
           committer: "${{ secrets.CI_USER }} <vald@vdaas.org>"
+          commit-message: "automated changes"
           signoff: true
           delete-branch: true
           base: main
+          branch: chore/update-actions
           title: "chore(deps): bump GitHub Actions dependency updates"
           body: "Automated pull request to update GitHub Actions dependencies."


### PR DESCRIPTION
We have implemented a workflow that performs dependency updates and automatically merges them. However, the changes in that PR need to be reflected in each release branch as well.
In this PR, I have implemented a workflow that backports the changes of the dependency update PR towards the release branch.
If CI in the backport PR is successful, it is merged into the release branch by the automatic merge workflow.

## NOTE

If the following PR are merged to the main branch, a backport PR will be created.
(The following PRs are automatically created if a dependency update is needed. )

- https://github.com/vdaas/vald-ci-labs/pull/338

Then, if the CI of the backport PR is successful, it is automatically merged to release branches.

- https://github.com/vdaas/vald-ci-labs/pull/341
- https://github.com/vdaas/vald-ci-labs/pull/340
- https://github.com/vdaas/vald-ci-labs/pull/339

-- 

By implementing the following workflow on the client side, the functionality implemented in this PR can be used.

```
name: "Run backport deps update PR"
on:
  push:
    branches:
      - main
jobs:
  backport:
    uses: vdaas/vald-client-ci/.github/workflows/_backport-deps.yaml@main
    ...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

### Release Notes

- **New Features**
  - Introduced a GitHub Actions workflow to automate backport dependency update pull requests.
  
- **Improvements**
  - Enhanced conditional logic for auto-merge based on pull request title and user login.
  - Updated pull request titles and bodies to follow a consistent naming convention for dependency updates.
  - Added the ability to set the branch name for pull request creation in dependency update workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->