### PR TITLE
Use ci container for pypy release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - uses: vdaas/vald-client-ci/.github/actions/setup-language@main
+        with:
+          client_type: python
       - name: Install dependencies
         run: |
           make REPO=vdaas ci/deps/install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 1
       - uses: vdaas/vald-client-ci/.github/actions/setup-language@main
         with:
-          client_type: ${{ inputs.client_type }}
+          client_type: node
       - name: Prepare for publish
         run: |
           make REPO=vdaas ci/package/prepare
@@ -111,6 +111,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - uses: vdaas/vald-client-ci/.github/actions/setup-language@main
+        with:
+          client_type: java
       - name: Prepare for publish
         run: |
           make REPO=vdaas ci/package/prepare
@@ -125,6 +128,9 @@ jobs:
       - release
     steps:
       - uses: actions/checkout@v4
+      - uses: vdaas/vald-client-ci/.github/actions/setup-language@main
+        with:
+          client_type: clj
       - name: Prepare for publish
         run: |
           make REPO=vdaas ci/package/prepare

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,9 @@ jobs:
   publish-pypl:
     if: ${{ startsWith( github.ref, 'refs/tags/') && inputs.client_type == 'python'}}
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vdaas/vald/vald-ci-container:nightly
+      options: "--add-host host.docker.internal:host-gateway"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `publish-pyp` job installs dependencies, but since it depends on vald-ci-container, the container must be specified in the job to run. In the previous code, the error occurred.

The following is an `publish-pypl` job

```yaml
  publish-pypl:
    ...
    container: <- added
      image: ghcr.io/vdaas/vald/vald-ci-container:nightly
      options: "--add-host host.docker.internal:host-gateway"
    steps:
      ....
      - name: Install dependencies
        run: |
          make REPO=vdaas ci/deps/install
      - name: Prepare for publish
        run: |
          make REPO=vdaas ci/package/prepare
      - name: Publish
        uses: pypa/gh-action-pypi-publish@v1
        with:
          user: ${{ secrets.PIP_USERNAME }}
          password: ${{ secrets.PIP_TOKEN }}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Improved consistency and isolation for the `publish-pypl` job by introducing a containerized environment.
	- Enhanced networking capabilities, allowing better communication between the container and the host system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->