### PR TITLE
Change version tag of gh-action-pypi-publish actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           make REPO=vdaas ci/package/prepare
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: ${{ secrets.PIP_USERNAME }}
           password: ${{ secrets.PIP_TOKEN }}

--- a/Makefile.d/function.mk
+++ b/Makefile.d/function.mk
@@ -25,6 +25,9 @@ define update-github-actions
 				if [ "$$ACTION_NAME" = "cirrus-actions/rebase" ]; then \
 					VERSION_PREFIX=$$VERSION; \
 					find $(ROOTDIR)/.github -type f -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \
+				elif [ "$$ACTION_NAME" = "pypa/gh-action-pypi-publish" ]; then \
+					VERSION_PREFIX=`echo $$VERSION | sed -E "s%^([0-9]+)\..*$$%release/v\1%"`; \
+					find $(ROOTDIR)/.github -type f -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@$$VERSION_PREFIX%g" {} +; \
 				elif echo $$VERSION | grep -qE '^[0-9]'; then \
 					VERSION_PREFIX=`echo $$VERSION | cut -c 1`; \
 					find $(ROOTDIR)/.github -type f -not -path "$(ROOTDIR)/.github/actions/setup-language/*" -exec sed -i "s%$$ACTION_NAME@.*%$$ACTION_NAME@v$$VERSION_PREFIX%g" {} +; \


### PR DESCRIPTION
The version tag specification was changed, so we also need to fix it in this repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the GitHub Actions workflow to specify a release version for publishing to PyPI, potentially improving the stability of the publishing process.
	- Enhanced the script to accommodate a new action type for versioning, allowing for better version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->