### PR TITLE
Bugfix/old makefile usage problem

### DIFF
--- a/.github/workflows/_sync.yaml
+++ b/.github/workflows/_sync.yaml
@@ -60,6 +60,8 @@ jobs:
       - name: Restore latest Makefile
         run: |
           git restore --source=origin/main -- Makefile
+          rm -rf Makefile.d/k3d.mk
+          curl -fsSL https://raw.githubusercontent.com/vdaas/vald-client-ci/refs/heads/main/Makefile.d/k3d.mk -o Makefile.d/k3d.mk
       - uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/_sync.yaml
+++ b/.github/workflows/_sync.yaml
@@ -60,8 +60,9 @@ jobs:
       - name: Restore latest Makefile
         run: |
           git restore --source=origin/main -- Makefile
-          rm -rf Makefile.d/k3d.mk
+          rm -rf Makefile.d/k3d.mk LICENSE
           curl -fsSL https://raw.githubusercontent.com/vdaas/vald-client-ci/refs/heads/main/Makefile.d/k3d.mk -o Makefile.d/k3d.mk
+          curl -fsSLo https://raw.githubusercontent.com/vdaas/vald/refs/heads/main/LICENSE
       - uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/_sync.yaml
+++ b/.github/workflows/_sync.yaml
@@ -57,6 +57,9 @@ jobs:
       - name: Set Git config
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Restore latest Makefile
+        run: |
+          git restore --source=origin/main -- Makefile
       - uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/Makefile.d/k3d.mk
+++ b/Makefile.d/k3d.mk
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2019-2024 vdaas.org vald team <vald@vdaas.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+K3D_CLUSTER_NAME  = "vald-cluster"
+K3D_COMMAND       = k3d
+K3D_NODES         = 5
+K3D_PORT          = 6550
+K3D_HOST          = localhost
+K3D_INGRESS_PORT  = 8081
+K3D_HOST_PID_MODE = true
+K3D_OPTIONS       = --port $(K3D_INGRESS_PORT):80@loadbalancer
+
+.PHONY: k3d/install
+## install K3D
+k3d/install: $(BINDIR)/k3d
+
+$(BINDIR)/k3d:
+	mkdir -p $(BINDIR)
+	curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+	chmod a+x $(BINDIR)/$(K3D_COMMAND)
+
+.PHONY: k3d/start
+## start k3d (kubernetes in docker) cluster
+k3d/start:
+	$(K3D_COMMAND) cluster create $(K3D_CLUSTER_NAME) \
+	  --agents $(K3D_NODES) \
+	  --image docker.io/rancher/k3s:$(K3S_VERSION) \
+	  --host-pid-mode=$(K3D_HOST_PID_MODE) \
+	  --api-port $(K3D_HOST):$(K3D_PORT) \
+	  -v "/lib/modules:/lib/modules" \
+	  $(K3D_OPTIONS)
+	@make k3d/config
+
+.PHONY: k3d/storage
+## storage k3d (kubernetes in docker) cluster
+k3d/storage:
+	kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+	kubectl get storageclass
+	kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+.PHONY: k3d/config
+## config k3d (kubernetes in docker) cluster
+k3d/config:
+	export KUBECONFIG="$(shell $(K3D_COMMAND) kubeconfig merge -o $(TEMP_DIR)/k3d_$(K3D_CLUSTER_NAME)_kubeconfig.yaml $(K3D_CLUSTER_NAME) --kubeconfig-switch-context)"
+
+.PHONY: k3d/restart
+## restart k3d (kubernetes in docker) cluster
+k3d/restart: \
+	k3d/delete \
+	k3d/start
+
+.PHONY: k3d/delete
+## stop k3d (kubernetes in docker) cluster
+k3d/delete:
+	-$(K3D_COMMAND) cluster delete $(K3D_CLUSTER_NAME)


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and adding a new Makefile for managing a k3d cluster. The most significant changes include restoring the latest Makefile in the GitHub Actions workflow and adding a new `Makefile.d/k3d.mk` file with various k3d-related targets.

### GitHub Actions Workflow Update:
* [`.github/workflows/_sync.yaml`](diffhunk://#diff-25d03d04cd37c05995535f88729b6f91d0eb2843755e0d16ff0e007c4ed0359bR60-R64): Added steps to restore the latest Makefile and download a specific k3d Makefile from a remote repository.

### New k3d Makefile:
* [`Makefile.d/k3d.mk`](diffhunk://#diff-2262c79da8835e986e6281d5bbe18f874312f2eb3425093808a28a42571f35afR1-R68): Added a new Makefile with targets for installing, starting, configuring, and managing a k3d (Kubernetes in Docker) cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Makefile for managing K3D clusters, including installation, startup, storage configuration, and cluster management operations.
- **Workflow Enhancements**
	- Added a step in the GitHub Actions workflow to ensure the latest Makefile is used during the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->