### PR TITLE
Add origin restore files (.github README.md .gitignore)

### DIFF
--- a/.github/workflows/_sync.yaml
+++ b/.github/workflows/_sync.yaml
@@ -59,7 +59,7 @@ jobs:
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - name: Restore latest Makefile
         run: |
-          git restore --source=origin/main -- Makefile
+          git restore --source=origin/main -- Makefile .github README.md .gitignore
           rm -rf Makefile.d/k3d.mk LICENSE
           curl -fsSL https://raw.githubusercontent.com/vdaas/vald-client-ci/refs/heads/main/Makefile.d/k3d.mk -o Makefile.d/k3d.mk
           curl -fsSLO https://raw.githubusercontent.com/vdaas/vald/refs/heads/main/LICENSE


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/_sync.yaml` file to enhance the restore process for several repository files. The most important change is the expansion of the `git restore` command to include additional files.

Enhancements to restore process:

* [`.github/workflows/_sync.yaml`](diffhunk://#diff-25d03d04cd37c05995535f88729b6f91d0eb2843755e0d16ff0e007c4ed0359bL62-R62): Modified the `git restore` command to include `Makefile`, `.github`, `README.md`, and `.gitignore` files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the GitHub Actions workflow to restore multiple files, including `Makefile`, `.github`, `README.md`, and `.gitignore`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->